### PR TITLE
Add a method to get a map position for a given scene coordinate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+/.nb-gradle/

--- a/src/main/java/com/gluonhq/impl/maps/BaseMap.java
+++ b/src/main/java/com/gluonhq/impl/maps/BaseMap.java
@@ -27,6 +27,7 @@
  */
 package com.gluonhq.impl.maps;
 
+import com.gluonhq.maps.MapPoint;
 import com.gluonhq.maps.MapView;
 import com.sun.javafx.tk.Toolkit;
 import javafx.beans.property.DoubleProperty;
@@ -254,6 +255,13 @@ public class BaseMap extends Group {
 
 
 
+    public MapPoint getMapPosition(double sceneX, double sceneY) {
+        final SimpleDoubleProperty _lat = new SimpleDoubleProperty();
+        final SimpleDoubleProperty _lon = new SimpleDoubleProperty();
+        calculateCoords(sceneX - getTranslateX(), sceneY - getTranslateY(), _lat, _lon);  
+        return new MapPoint(_lat.get(), _lon.get());
+    }
+    
     public Point2D getMapPoint(double lat, double lon) {
         return getMapPoint(zoom.get(), lat, lon);
     }
@@ -471,12 +479,16 @@ public class BaseMap extends Group {
     private void calculateCenterCoords() {
         double x = ((MapView)this.getParent()).getWidth()/2-this.getTranslateX();
         double y = ((MapView)this.getParent()).getHeight()/2 - this.getTranslateY();
+        calculateCoords(x, y, centerLat, centerLon);
+    }
+    
+    private void calculateCoords(double x, double y, SimpleDoubleProperty lat, SimpleDoubleProperty lon) {        
         double z = zoom.get();
         double latrad = Math.PI - (2.0 * Math.PI * y) / (Math.pow(2, z)*256.);
         double mlat = Math.toDegrees(Math.atan(Math.sinh(latrad)));
         double mlon = x / (256*Math.pow(2, z)) * 360 - 180;
-        centerLon.set(mlon);
-        centerLat.set(mlat);
+        lon.set(mlon);
+        lat.set(mlat);
     }
     
     /**

--- a/src/main/java/com/gluonhq/maps/MapView.java
+++ b/src/main/java/com/gluonhq/maps/MapView.java
@@ -103,6 +103,17 @@ public class MapView extends Region {
         }
     }
 
+   /**
+     * Get the position on the map represented by a given coordinate
+     *
+     * @param sceneX x coordinate
+     * @param sceneY y coordinate
+     * @return map position
+     */
+    public MapPoint getMapPosition(double sceneX, double sceneY) {
+        return baseMap.getMapPosition(sceneX, sceneY);
+    }
+
     /**
      * Request the map to set its zoom level to the specified value. The map
      * considers this request, but it does not guarantee the zoom level will be


### PR DESCRIPTION
This pull request adds a method to get a map position for a given scene coordinate. The use case for this is to be able to place something on a layer based on the location within a scene, for example after a mouse button has been pressed.

As you can see, existing code in calculateCenterCoords() has been reused by refactoring it into a new method called calculateCoords(), which is called from calculateCenterCoords().